### PR TITLE
feat: add authentication to activity routes

### DIFF
--- a/src/activities/activities.controller.ts
+++ b/src/activities/activities.controller.ts
@@ -22,34 +22,54 @@ import { JwtAuthGuard } from 'src/auth/jwt/jwt-auth.guard';
 export class ActivitiesController {
   constructor(private readonly activitiesService: ActivitiesService) {}
 
+  /**
+   * Create an Activity for the user making the request with the given body
+   */
   @Post()
   @UseGuards(JwtAuthGuard)
   create(@Req() req: any, @Body() createActivityDto: CreateActivityDto) {
     return this.activitiesService.create(req.user.sub, createActivityDto);
   }
 
+  /**
+   * Get a list of all of the activities for a user. The default user is
+   * the user making the request. If an alternate user is provided, then
+   * the user making the request must have permissions above FACULTY
+   * @param userId? alternate user to list all activities for
+   * @param category? filter for only activities in this category
+   * @param significance? filter for only activities with this
+   */
   @Get('all')
   @UseGuards(JwtAuthGuard)
   findAll(
     @Req() req: any,
     @Query('userId') userId?: string | undefined,
     @Query('category') category?: ActivityCategory | undefined,
-    @Query('significance') signifiance?: SignificanceLevel | undefined,
+    @Query('significance') significance?: SignificanceLevel | undefined,
   ) {
     return this.activitiesService.findFilter(
       req.user.sub,
       userId,
       category,
-      signifiance,
+      significance,
     );
   }
 
+  /**
+   * Get the Activity with the given ID. User making request must either
+   * be the user associated with the Activity, or have permissions higher than
+   * FACULTY
+   */
   @Get(':id')
   @UseGuards(JwtAuthGuard)
   findOne(@Req() req: any, @Param('id') id: string) {
     return this.activitiesService.findOne(req.user.sub, +id);
   }
 
+  /**
+   * Update the Activity with the given ID using the given body. User making request
+   * must be the user associated with the Activity.
+   */
   @Patch(':id')
   @UseGuards(JwtAuthGuard)
   update(
@@ -60,6 +80,10 @@ export class ActivitiesController {
     return this.activitiesService.update(req.user.sub, +id, updateActivityDto);
   }
 
+  /**
+   * Delete the Activity with the given ID. User making request
+   * must be the user associated with the Activity.
+   */
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
   remove(@Req() req: any, @Param('id') id: string) {

--- a/src/activities/activities.service.ts
+++ b/src/activities/activities.service.ts
@@ -15,7 +15,6 @@ export class ActivitiesService {
   constructor(private prisma: PrismaService) {}
 
   create(userId: number, createActivityDto: CreateActivityDto) {
-    console.log({ ...createActivityDto, userId: userId });
     return this.prisma.activity.create({
       data: { ...createActivityDto, userId: userId },
     });

--- a/src/activities/dto/create-activity.dto.ts
+++ b/src/activities/dto/create-activity.dto.ts
@@ -3,9 +3,6 @@ import { ActivityCategory, SignificanceLevel } from '@prisma/client';
 
 export class CreateActivityDto {
   @ApiProperty()
-  userId: number;
-
-  @ApiProperty()
   academicYearId: number;
 
   @ApiProperty()


### PR DESCRIPTION
### Summary
Add authentication to all of the activity routes.

1. `POST` route: DTO no longer includes userId, userId is gotten from the request body
2. `GET` all route: Moved userId from parameter to query parameter. Default user searched for is the userId in the request. If a userId was provided as a query parameter, we ensure that either 1) the query parameter is the same as the user making the request or 2) the user making the request has admin permissions
3. `GET` detail route: user making request must either have admin permissions or be the user associated with the given ID
4. `PATCH` and `DELETE` route: user making request must be the user in the activity